### PR TITLE
[Mozilla Branding Removal] Update GitHub workflow file

### DIFF
--- a/.github/workflows/hubs-docs.yml
+++ b/.github/workflows/hubs-docs.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}


### PR DESCRIPTION
Update the turkeyGitops URL and the Docker registry to the Hubs Foundation versions.
This allows the workflow to run successfully and output a Docker image.