### PR TITLE
fixes syntax error in sync-publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
           echo "${{ secrets.WEBCONTAINERS_KEY }}" >  ~/.ssh/WEBCONTAINERS_KEY
           chmod 600 ~/.ssh/WEBCONTAINERS_KEY
           echo ${{ vars.KNOWN_HOSTS }} > ~/.ssh/known_hosts
-          rsync -v ---rsh='ssh -i  ~/.ssh/WEBCONTAINERS_KEY' --archive --delete-after $source $dest
+          rsync -v --rsh='ssh -i  ~/.ssh/WEBCONTAINERS_KEY' --archive --delete-after $source $dest


### PR DESCRIPTION
## What?
removes extra dash in rsync argument


## Why?
The --rsh='foo' argument has only two dashes.


## How to test
Check that workflow actually syncs the files to docs.hubsfoundation.org

