### PR TITLE
Adds quotes around KNOWN_HOSTS variable in build_sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,5 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.WEBCONTAINERS_KEY }}" >  ~/.ssh/WEBCONTAINERS_KEY
           chmod 600 ~/.ssh/WEBCONTAINERS_KEY
-          echo ${{ vars.KNOWN_HOSTS }} > ~/.ssh/known_hosts
+          echo "${{ vars.KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           rsync -v --rsh='ssh -i  ~/.ssh/WEBCONTAINERS_KEY' --archive --delete-after $source $dest


### PR DESCRIPTION
## What?
Properly quotes the KNOWN_HOSTS variable so it can have multiple lines.


## Why?
KNOWN_HOSTS in general has multiple lines for multiple keys and multiple hosts.


## How to test
Workflow will complete without error if this is the only problem.