### PR TITLE
Publishes to proper hostname: hubsfoundation.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' && github.repository == 'Hubs-Foundation/hubs-docs' }}
         env:
           source: build/hubs-docs/
-          dest: webcontainers@web-containers.hubsfoundation.org:wordpress/hubs-docs
+          dest: webcontainers@hubsfoundation.org:wordpress/hubs-docs
         run: |
           env
           mkdir -p ~/.ssh


### PR DESCRIPTION
## What?
Changes the hostname where these docs are published from web-containers.hubsfoundation.org to hubsfoundation.org.

## Why?
The previous value was temporary, until we could move the wordpress site over.

## How to test

The GitHub `publish` workflow should complete successfully.
