### PR TITLE
Fixes a number of broken links and changes http: links to https:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is for the documentation for Hubs, and related products such as Community Edition and Spoke.
 
-The documentation is under active development. If there are any changes or updates you recommend, feel free to submit a pull request or let us know in our [Discord Server](http://discord.gg/wHmY4nd).
+The documentation is under active development. If there are any changes or updates you recommend, feel free to submit a pull request or let us know in our [Discord Server](https://discord.gg/wHmY4nd).
 
 This website was created with [Docusaurus](https://docusaurus.io/). 
 

--- a/docs/admin-enable-scene-editor.md
+++ b/docs/admin-enable-scene-editor.md
@@ -1,10 +1,10 @@
 ---
 id: admin-enable-scene-editor
-title: Recipe: Enable Scene Editor
-sidebar_label: Recipe: Enable Scene Editor
+title: "Recipe: Enable Scene Editor"
+sidebar_label: "Recipe: Enable Scene Editor"
 ---
 
-Hubs Cloud includes an unbranded version of [Spoke](http://hubs.local:3000/docs/spoke-creating-projects.html) called the **Scene Editor** can you can use to create custom 3D scenes.
+Hubs Cloud includes an unbranded version of [Spoke](./spoke-creating-projects.md) called the **Scene Editor** can you can use to create custom 3D scenes.
 
 Out of the box, it is disabled for non-administrators. If you want your users to be able to create and edit custom scenes when using your hub, you can enable the Scene Editor for all users.
 

--- a/docs/hubs-cloud-accessing-servers.md
+++ b/docs/hubs-cloud-accessing-servers.md
@@ -6,7 +6,7 @@ sidebar_label: Advanced: SSH Access
 
 To access your servers over SSH, in the [Admin Console](./admin-getting-started) choose **Server Access** and follow the guide. Note that 2-factor authentication is set up by default, so you will need a 2FA device with an application installed like Google Authenticator to connect to your servers.
 
-Your servers are running [Ubuntu 18.04 Bionic Beaver](http://releases.ubuntu.com/18.04/).
+Your servers are running [Ubuntu 18.04 Bionic Beaver](https://releases.ubuntu.com/18.04/).
 
 ### Biome Services
 

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -112,17 +112,24 @@ Check out the [troubleshooting](hubs-troubleshooting.html#there-is-echo-in-the-r
 
 Hubs rooms can only be accessed by individuals with the URL. 
 
-<!-- Authentication can be done either the [Hubs Discord Bot](hubs-discord-bot.html), or using an approved list of users in [Hubs Cloud](https://hubs.mozilla.com/cloud). -->
+ Authentication can be done using the [Hubs Discord Bot](hubs-discord-bot.html).
 
-<!-- ## Can I run custom code in a Hubs room?
+[//]: # ( , or using an approved list of users in [Hubs Cloud]&#40;https://hubs.mozilla.com/cloud&#41;.)
 
-You can't run custom code in the main Hubs website (hubs.mozilla.com) but you can add your own if you self-host using Hubs Cloud (see previous answers). To add custom code you will need to create your own custom fork of the Hubs Cloud client.
+[//]: # (## Can I run custom code in a Hubs room?)
 
-For more information, see our documentation on [custom clients](./hubs-cloud-custom-clients.html). -->
+[//]: # ()
+[//]: # (You can't run custom code in the main Hubs website &#40;hubs.mozilla.com&#41; but you can add your own if you self-host using Hubs Cloud &#40;see previous answers&#41;. To add custom code you will need to create your own custom fork of the Hubs Cloud client.)
 
-<!-- ##  Is it possible for me to create a custom version of Hubs which has different features or styling? 
+[//]: # ()
+[//]: # (For more information, see our documentation on [custom clients]&#40;./hubs-cloud-custom-clients.html&#41;. )
 
-See previous answer.  -->
+
+[//]: # (##  Is it possible for me to create a custom version of Hubs which has different features or styling? )
+
+[//]: # ()
+[//]: # (See previous answer.  )
+
 
 ## Can I pay Hubs-Foundation to do X, Y, Z?
 It's not possible to pay Hubs-Foundation for custom work, however, our code is open source and we welcome external contributors in [GitHub](http://github.com/Hubs-Foundation/hubs). You can post in the #work-for-hire channel of our [Discord chat server](https://discord.gg/wHmY4nd) if you are interested in paying someone to build something for you.

--- a/docs/intro-avatars.md
+++ b/docs/intro-avatars.md
@@ -33,7 +33,6 @@ The most straightforward way to customize an avatar for Hubs is to upload a cust
 ### Create a robot texture
 
 The easiest way to design a new skin for a robot avatar is to use our avatar re-skinning tool 'Quilt' to mix together image files, preview  what they look like on a robot and export a single texture map file. 
-<!-- Try it yourself at [tryquilt.io](http://tryquilt.io/).  -->
 
 ![Examples of robot avatars](img/intro-hubs-tryquilt.jpeg)
 

--- a/docs/setup-custom-client.md
+++ b/docs/setup-custom-client.md
@@ -36,7 +36,7 @@ If you need more assistance, we recommend following along with our [Custom Clien
 
 3. Change directory into the folder of your project and run `npm run dev` to start a development server. Once the code has compiled, you will be able to access this development server at `localhost:8080` on your web browser.
 
-4. Add your customizations to the Hubs code. See the [For Developers](http://localhost:3000/docs/system-overview.html) section of these docs for information about how to get started with your customizations.
+4. Add your customizations to the Hubs code. See the [For Developers](./system-overview.html) section of these docs for information about how to get started with your customizations.
 
 &nbsp;&nbsp;&nbsp;<u>**Troubleshooting**</u>
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -76,7 +76,7 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
-            <a href="http://discord.gg/wHmY4nd">Discord Chat</a>
+            <a href="https://discord.gg/wHmY4nd">Discord Chat</a>
             {/* <a
               href="https://twitter.com/hubsfoundation"
               target="_blank"


### PR DESCRIPTION
## What?
Fixes a number of broken links and changes http: links to https:
Also changes some HTML commenting to Markdown commenting.


## Why?
a number of links. pointed to localhost:3000
http: links are no longer secure.
Using HTML comments in a Markdown file does not work as expected and hid content that should have been visible.


## Limitations
Page content still needs a review to see if it's still accurate. 

