### PR TITLE
Sets metadata description to something useful, where Docusaurus fails

### DIFF
--- a/docs/admin-adding-administrators.md
+++ b/docs/admin-adding-administrators.md
@@ -2,6 +2,7 @@
 id: admin-adding-administrators
 title: Adding Administrators
 sidebar_label: Adding Administrators
+description: Administrative powers and granting them to accounts
 ---
 
 ## Powers

--- a/docs/admin-getting-started.md
+++ b/docs/admin-getting-started.md
@@ -2,6 +2,7 @@
 id: admin-getting-started
 title: Getting Started With Administration
 sidebar_label: Getting Started
+description: Signing in and creating and configuring a room
 ---
 
 ## Admin Panel

--- a/docs/creators-advanced-avatar-customization.md
+++ b/docs/creators-advanced-avatar-customization.md
@@ -1,6 +1,7 @@
 ---
 id: creators-advanced-avatar-customization
 title: Advanced Avatar Customization
+description: Re-skinning an existing avatar, or creating one from scratch
 ---
 
 ## Advanced Re-skinning 

--- a/docs/creators-blender-components.md
+++ b/docs/creators-blender-components.md
@@ -1,7 +1,7 @@
 ---
 id: creators-blender-components
 title: Blender Add-on Components
-description: Many Hubs Components can be adding to a scene when creating it in Blender. 
+description: Many Hubs Components can be added to a scene when creating it in Blender.
 ---
 
 ## Overview

--- a/docs/creators-blender-components.md
+++ b/docs/creators-blender-components.md
@@ -1,6 +1,7 @@
 ---
 id: creators-blender-components
 title: Blender Add-on Components
+description: Many Hubs Components can be adding to a scene when creating it in Blender. 
 ---
 
 ## Overview

--- a/docs/creators-optimization.md
+++ b/docs/creators-optimization.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-optimization
 title: Optimizing Scenes
+description: Measuring and improving performance across many devices.
 ---
 
 ## Improving Performance

--- a/docs/creators-using-the-blender-gltf-exporter.md
+++ b/docs/creators-using-the-blender-gltf-exporter.md
@@ -1,6 +1,7 @@
 ---
 id: creators-using-the-blender-gltf-exporter
 title: Using the Blender glTF Exporter
+description: 3-D models can be created using the advanced tools of Blender, and exported to a format that Hubs can read.
 ---
  Note: The following documentation assumes you are using the latest stable release of Blender. Using older versions or experimental builds of Blender may work, but is not guaranteed.
  
@@ -9,7 +10,7 @@ To ensure you are using the latest release of Blender, look at the top right of 
 ![Blender Splash Screen Image](img/BlenderSplash.jpg)
 
 
-### What things will export to glTF?
+## What things will export to glTF?
 Not everything you make in Blender can be exported to the glTF (glb) format. This is constantly changing due to ongoing improvements to the Blender glTF importer/exporter add-on, as well as changes to the glTF file format itself. Generally speaking, you can export models with or without textures and/or vertex colors, models with skeletal armatures, models with shape keys (morphing), and models with animation. Things that will *not* export properly (unless things change at some point): Blender's particle systems, cached vertex animations (like fluid or cloth simulations), and certain types of shaders, to name a few.
 
 If you have questions or problems getting certain parts of your Blender file to export, please refer to the following for more information:
@@ -18,7 +19,7 @@ If you have questions or problems getting certain parts of your Blender file to 
 
 [Blender glTF Importer/Exporter Github repository](https://github.com/KhronosGroup/glTF-Blender-IO)
 
-### How to make sure your Blender model(s) export correctly
+## How to make sure your Blender model(s) export correctly
 There are a few things to check to make sure what you see in Blender is what you'll get in Spoke and Hubs. This is not an exhaustive list, but it contains some common things that can cause unexpected results.
 
 **+ The scale should read 1, 1, 1.**
@@ -67,7 +68,7 @@ Any parameters not mentioned are probably best left to their defaults.
 It's worth noting that because this exporter (and the glTF format) is still subject to its own bug fixes and redesign, some of the settings and/or their defaults may change in the future.
 
 
-### Setting up materials that Spoke and Hubs will display correctly
+## Setting up materials that Spoke and Hubs will display correctly
 
 Blender's documentation has all of the latest information about how materials should be configured for glTF. This information can be found easily by searching for 'glTF' in their docs. Here's the [link to Blender's glTF documentation](https://docs.blender.org/manual/en/dev/addons/import_export/scene_gltf2.html?highlight=gltf#gltf-2-0)
 

--- a/docs/dev-client-basics.md
+++ b/docs/dev-client-basics.md
@@ -3,9 +3,8 @@ id: dev-client-basics
 title: Hubs Client development Basics
 ---
 
-The Hubs client is a web application that runs in each user&rsquo;s web
-browser. It contains the HTML, CSS, and Javascript necessary to simulate a
-networked 3D world and display interactive 2D menus. This document provides
+The Hubs client is a web application that runs in each user&rsquo;s web browser. It contains the HTML, CSS, and Javascript necessary to simulate a networked 3D world and display interactive 2D menus.
+This document provides
 an overview of the Hubs client: the technologies it uses, the backend services
 it connects to, and how its code is organized.
 

--- a/docs/dev-client-basics.md
+++ b/docs/dev-client-basics.md
@@ -1,6 +1,7 @@
 ---
 id: dev-client-basics
 title: Hubs Client development Basics
+description: Basic description of Hubs technologies and the backend services required to run Hubs.
 ---
 
 The Hubs client is a web application that runs in each user&rsquo;s web browser. It contains the HTML, CSS, and Javascript necessary to simulate a networked 3D world and display interactive 2D menus.

--- a/docs/dev-client-gameplay.md
+++ b/docs/dev-client-gameplay.md
@@ -1,6 +1,7 @@
 ---
 id: dev-client-gameplay
 title: Core Concepts for Gameplay Code
+description: The core concepts for writing gameplay code in the Hubs client
 ---
 
 ## Intro

--- a/docs/dev-client-networking.md
+++ b/docs/dev-client-networking.md
@@ -1,6 +1,7 @@
 ---
 id: dev-client-networking
 title: Hubs Client development Networking
+description: The way that entity state is networked across clients and optionally persisted to the database.
 ---
 
 ## Intro

--- a/docs/dev-github-workflows.md
+++ b/docs/dev-github-workflows.md
@@ -1,14 +1,15 @@
 ---
 id: github-workflows
 title: GitHub Workflows
+description: Continuous Integration rebuilds the containers used in the deployment of Hubs
 ---
 
-# Custom Docker Build Push
+## Custom Docker Build Push
 In some repositories you will find a GitHub Workflow/Action named custom-docker-build-push for building custom docker images and pushing them to a docker/container registry of your choice.  Simply run this Action on any branch, with the appropriate details filled in (either through the predefined defaults or by the overrides), and you will end up with a docker image of that branch that can be used in any Community Edition instance.
 
 The Action allows you almost complete control over where your docker images are sent and how they are tagged.  The details required for this to work can either be provided at runtime or by preset defaults that you set up.
 
-## Options/Setup
+### Options/Setup
 
 The following properties can be configured/overridden.  Any values that are manually specified for that run will always be used.  Any fields not passed values will fall back on predefined variables/secrets (if they have been created).
 

--- a/docs/dev-github-workflows.md
+++ b/docs/dev-github-workflows.md
@@ -1,7 +1,7 @@
 ---
 id: github-workflows
 title: GitHub Workflows
-description: Continuous Integration rebuilds the containers used in the deployment of Hubs
+description: Explanations of workflows for Hubs deployments including instructions for use. 
 ---
 
 ## Custom Docker Build Push

--- a/docs/dev-system-overview.md
+++ b/docs/dev-system-overview.md
@@ -1,6 +1,7 @@
 ---
 id: system-overview
 title: System Overview
+description: The components and technologies that make up Hubs
 ---
 
 # [The Client](https://github.com/Hubs-Foundation/hubs) 

--- a/docs/hubs-controls.md
+++ b/docs/hubs-controls.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-controls
 title: Controls
+description: Keyboard, mouse, and controllers for personal computers, PC headsets, standalone headsets, phone headsets, and gamepads
 ---
 <!-- 
 https://truben.no/table/ to edit these tables

--- a/docs/hubs-create-join-rooms.md
+++ b/docs/hubs-create-join-rooms.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-create-join-rooms
 title: Create and Join Rooms
+description: The process and details of creating and joining a Hubs room
 ---
 
 ## Create a New Room

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -1,7 +1,7 @@
 ---
 id: hubs-faq
 title: FAQ
-description: How to present content and smoothly run events in Hubs
+description: Common questions about using Hubs
 ---
 
 ## What is the capacity of a Hubs room?

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-faq
 title: FAQ
+description: How to present content and smoothly run events in Hubs
 ---
 
 ## What is the capacity of a Hubs room?

--- a/docs/hubs-features.md
+++ b/docs/hubs-features.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-features
 title: Hubs Features
+description: 'Hubs user interface: menus for objects, avatars, the camera, and drawing; controls; and spawners'
 ---
 
 ![Hubs User Interface](img/hubs-user-interface.png)

--- a/docs/hubs-room-settings.md
+++ b/docs/hubs-room-settings.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-room-settings
 title: Room Settings
+description: Changing the scene, room name, access, and permissions. Moderating users. Discord authentication.
 ---
 
 ## Change the Scene

--- a/docs/hubs-troubleshooting.md
+++ b/docs/hubs-troubleshooting.md
@@ -1,9 +1,10 @@
 ---
 id: hubs-troubleshooting
 title: Troubleshooting
+description: Dealing with some common connection and performance problems in Hubs
 ---
 
-## Getting stuck on loading screen 
+## Getting stuck on loading screen
 
 Rooms may have complex 3D models or objects in them which can increase the load time, particularly on less powerful devices (i.e., mobile phones and standalone VR headsets). If you are getting stuck on the loading screen, try refreshing the page or loading the scene on another browser or device. 
 

--- a/docs/hubs-user-settings.md
+++ b/docs/hubs-user-settings.md
@@ -1,7 +1,7 @@
 ---
 id: hubs-user-settings
 title: User Settings
-description: Changing name, avatar, and preferences; features available only when you sign in
+description: Changing name, avatar and preferences, and features that are only available when you sign in
 ---
 
 ## Changing Name and Avatar

--- a/docs/hubs-user-settings.md
+++ b/docs/hubs-user-settings.md
@@ -1,6 +1,7 @@
 ---
 id: hubs-user-settings
 title: User Settings
+description: Changing name, avatar, and preferences; features available only when you sign in
 ---
 
 ## Changing Name and Avatar

--- a/docs/intro-behavior-graphs.md
+++ b/docs/intro-behavior-graphs.md
@@ -1,6 +1,7 @@
 ---
 id: intro-behavior-graphs
 title: Introduction to Behavior Graphs
+description: Behavior graphs allow for control over many aspects of a Hubs experience by exposing Hubs-specific features normally only accessible via altering the Hubs code base. Things like teleporting, audio zones, video playback, or in-world events like when a person joins or leaves a room can all be accessed through a graphical system of connected nodes or blocks (like a flowchart) from within Blender.
 ---
 
 > **NOTE:** _As of this documentation being created, Behavior Graphs are undergoing rapid development. This has the effect of making it challenging to update this documentation quickly enough to make sure it has parity with the current state of the tech behind it. Thank you for your patience and please consider contributing edits to this documentation as needed._

--- a/docs/intro-behavior-graphs.md
+++ b/docs/intro-behavior-graphs.md
@@ -1,7 +1,7 @@
 ---
 id: intro-behavior-graphs
 title: Introduction to Behavior Graphs
-description: Behavior graphs allow for control over many aspects of a Hubs experience by exposing Hubs-specific features normally only accessible via altering the Hubs code base. Things like teleporting, audio zones, video playback, or in-world events like when a person joins or leaves a room can all be accessed through a graphical system of connected nodes or blocks (like a flowchart) from within Blender.
+description: Behavior graphs allow for adding interactivity to Hubs through a graphical system of connected nodes or blocks from within Blender.
 ---
 
 > **NOTE:** _As of this documentation being created, Behavior Graphs are undergoing rapid development. This has the effect of making it challenging to update this documentation quickly enough to make sure it has parity with the current state of the tech behind it. Thank you for your patience and please consider contributing edits to this documentation as needed._

--- a/docs/intro-events.md
+++ b/docs/intro-events.md
@@ -2,6 +2,7 @@
 id: intro-events
 title: Hosting Events in Hubs
 sidebar_label: Hosting Events in Hubs
+description: Outlines the process of setting up Hubs for an event and inviting people
 ---
 
 <!-- This guide will talk you through the process of using Hubs for an event on [Mozilla Hubs](https://hubs.mozilla.com). We've broken this guide down into different sections that can help you get started with creating and configuring a room, choosing a custom scene, inviting people, and moderating your event.  -->

--- a/docs/intro-hubs.md
+++ b/docs/intro-hubs.md
@@ -1,7 +1,8 @@
 ---
 id: intro-hubs
 title: Getting Started with Hubs
-sidebar_label: Getting Started With Hubs 
+sidebar_label: Getting Started With Hubs
+description: How to enter a Hubs room, move around, basic interaction, add media, and invite friends.
 ---
 
 

--- a/docs/setup-faq.md
+++ b/docs/setup-faq.md
@@ -1,7 +1,7 @@
 ---
 id: setup-faq
 title: Frequently Asked Questions
-description: terminology, limits and custom versions of Hubs
+description: The terminology and limits of Hubs, and custom versions
 ---
 
 ## Can I have more than one Hub with my account?

--- a/docs/setup-faq.md
+++ b/docs/setup-faq.md
@@ -1,23 +1,24 @@
 ---
 id: setup-faq
 title: Frequently Asked Questions
+description: terminology, limits and custom versions of Hubs
 ---
 
-### Can I have more than one Hub with my account?
+## Can I have more than one Hub with my account?
 
 Since currently hosting is the responsibility of the user, there is no limit to the number of Hubs you can build. 
 
-### What happens if I exceed my Hub's content storage limit?
+## What happens if I exceed my Hub's content storage limit?
 
 Your Hub's content storage limit is the total of all data associated with your Hub, largely composed of media uploaded via Spoke and the Admin Panel. If you have exceed the storage limit, you will experience errors when attempting to upload additional media via Spoke and the Admin Panel.
 
-### What happens if I exceed my Hub's concurrent user limit?
+## What happens if I exceed my Hub's concurrent user limit?
 
 Exceeding the optimal number of concurrent users will greatly affect the stability and performance of your hub. Most often, new users will receive a persistent 503 error when attempting to connect.
 
 <img src="img/503-error.png" alt="The 503 error displayed when over ccu limit">
 
-### What is the difference between a 'hub, a 'room', a 'space', and a 'scene'?
+## What is the difference between a 'hub, a 'room', a 'space', and a 'scene'?
 
 A 'hub' refers to the instance of Hubs associated with your account. It is composed of your server and the tools, rooms, worlds, and other media that exist on top of it.
 
@@ -25,11 +26,11 @@ Understanding the difference between a 'room' and a 'scene' is a key concept for
 
 'Space' and 'scene' are used interchangably throughout our documentation. You can upload an unlimited number of spaces/scenes on your Hub, as long as your Hub's total content stays within the data limit of your subscription plan.
 
-### Can I also deploy a custom version of Spoke?
+## Can I also deploy a custom version of Spoke?
 
 While custom Spoke deployments are not currently supported, we hope to be able to enable them soon. However, we are using the [Hubs Blender Add On](https://github.com/Hubs-Foundation/hubs-blender-exporter) to develop and expose new features for designing worlds in Hubs. We highly recommend moving your custom Spoke features to the Blender Add-On.
 
-### I am interested in deploying a custom client to my Hub. How can I keep up with the Hubs Team's regular releases?
+## I am interested in deploying a custom client to my Hub. How can I keep up with the Hubs Team's regular releases?
 
 The best way to keep your custom client up to date is to follow our releases on the `master` branch of the [Hubs github repo](https://github.com/Hubs-Foundation/hubs).
 

--- a/docs/spoke-grid.md
+++ b/docs/spoke-grid.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-grid
 title: Grid
+description: Grid and Snap Mode of Spoke
 ---
 
 ![Screenshot of Spoke](img/spoke-grid.png)

--- a/docs/spoke-lighting-and-shadows.md
+++ b/docs/spoke-lighting-and-shadows.md
@@ -1,6 +1,7 @@
 ---
 id: lighting-and-shadows
 title: Lighting and Shadows
+description: Types of lights, shadow settings, and performance impacts in Spoke
 ---
 
 ## Lights

--- a/docs/spoke-physics-and-navigation.md
+++ b/docs/spoke-physics-and-navigation.md
@@ -1,6 +1,7 @@
 ---
 id: physics-and-navigation
 title: Physics and Navigation
+description: Constraining where avatars can and can't go
 ---
 
 # The Floorplan Element

--- a/docs/spoke-user-interface.md
+++ b/docs/spoke-user-interface.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-user-interface
 title: User Interface
+description: Menus, tools, mouse actions, info panels, assets and publishing in Spoke
 ---
 
 ![Hubs Image](img/spoke-user-interface.jpeg)

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -2,6 +2,7 @@
 id: welcome
 title: Welcome to Hubs
 sidebar_label: Welcome
+description: Hubs is a virtual collaboration platform that runs in your browser. With Hubs you can create your own 3D spaces with a single click. Invite others to join using a URL. No installation or app store required.
 ---
 
 **Important Notice:** A significant portion of this documentation contains outdated information.  There are ongoing efforts to update it. Chiefly, Hubs by Mozilla and Hubs Cloud are obsolete.  Hubs Community Edition has the same user experience.  Got questions?  Our community Discord is standing by.  https://discord.gg/hubs-498741086295031808


### PR DESCRIPTION

## What?
Where Docusaurus was generating a poor metadata description of a page, explicitly sets description in source file


## Why?
Social media previews (and some search indexes) display the meta description tag. Docusaurus uses the first content line, unless you set the description in metadata. For many pages, the first line is useless, or even commented-out material. Sometimes it's good, and those pages weren't changed. Social media previews are often one of the first part of Hubs seen, and we don't want to look unprofessional.

## Examples of the problem
I was helping a user today, and this text was what appeared in Discord, that isn't displayed on the page proper, because it needs to be updated:
![Screenshot 2025-05-10 at 11 19 17 AM](https://github.com/user-attachments/assets/490a37f5-a265-436d-99b7-a7be3dde6a78)

For the Controls page, there isn't even any text:
![image](https://github.com/user-attachments/assets/10ff002b-c73f-4ac6-909d-b82adbcde83b)

## How to test
1. Pull this branch
2. run `npm write-translations`
3. run `npm start`
4. In the browser, for each changed page, open the Developer Tools, select the Elements tab, click the arrow to open the HEAD tag, and read the meta description element


## Alternatives considered
It's possible to write a page so the first content line makes a good description.
Then, the description doesn't need to be separatly recorded.

