### PR TITLE
Update page descriptions

### DIFF
--- a/docs/hubs-query-string-parameters.md
+++ b/docs/hubs-query-string-parameters.md
@@ -2,6 +2,7 @@
 id: hubs-query-string-parameters
 title: Hubs Query String Parameters
 sidebar_label: Hubs Query String Parameters
+description: Hubs allow for some programming based settings that do not appear in room settings. Text commands such as forcing mobile material quality and debugging the Local Scene.  Most users will not need to use these commands.
 ---
 
 Some developer-oriented options that are not available in the preferences panel in Hubs are available as query string parameters. These are intended mainly for development or debugging and are not something most users will need to use.

--- a/docs/hubs-room-settings.md
+++ b/docs/hubs-room-settings.md
@@ -1,7 +1,7 @@
 ---
 id: hubs-room-settings
 title: Room Settings
-description: Changing the scene, room name, access, and permissions. Moderating users. Discord authentication.
+description: Hubs rooms options include creating a custom name, setting access and permissions, what favorite room does, and closing a room.
 ---
 
 ## Change the Scene

--- a/docs/hubs-troubleshooting.md
+++ b/docs/hubs-troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 id: hubs-troubleshooting
 title: Troubleshooting
-description: Dealing with some common connection and performance problems in Hubs
+description: Frequently asked questions regarding user issues like microphones, screen sharing, and objects disappearing.
 ---
 
 ## Getting stuck on loading screen

--- a/docs/hubs-user-settings.md
+++ b/docs/hubs-user-settings.md
@@ -1,7 +1,7 @@
 ---
 id: hubs-user-settings
 title: User Settings
-description: Changing name, avatar and preferences, and features that are only available when you sign in
+description: Instructions for how a user can change their avatar and set preferences for things like sound and movement. Benefits for using a user account (via an email address) are listed.
 ---
 
 ## Changing Name and Avatar

--- a/docs/intro-avatars.md
+++ b/docs/intro-avatars.md
@@ -1,6 +1,7 @@
 ---
 id: intro-avatars
 title: Creating Custom Avatars
+description: Instructions on how to re-skin a robot or box avatar.
 ---
 
 In Hubs you can choose how you want to represent yourself. Select from any of the featured or newest avatars, or create your own. 

--- a/docs/intro-behavior-graphs.md
+++ b/docs/intro-behavior-graphs.md
@@ -1,7 +1,7 @@
 ---
 id: intro-behavior-graphs
 title: Introduction to Behavior Graphs
-description: Behavior graphs allow for adding interactivity to Hubs through a graphical system of connected nodes or blocks from within Blender.
+description: Behavior graphs (BG) are a form of visual scripting or a graphical depictions of interactions possible with Hubs. This documentation uses Blender to add or modify things like teleporting, video playback, lights, animation speed, and object location. Behavior graphs are in current development. While building a behavior graph does not require complex programming, hosting a BG-enabled Hubs instance is not for the fearful; behavior graphs break some Hubs features while adding other features.  We will get the bugs worked out eventually. 
 ---
 
 > **NOTE:** _As of this documentation being created, Behavior Graphs are undergoing rapid development. This has the effect of making it challenging to update this documentation quickly enough to make sure it has parity with the current state of the tech behind it. Thank you for your patience and please consider contributing edits to this documentation as needed._

--- a/docs/intro-events.md
+++ b/docs/intro-events.md
@@ -2,7 +2,7 @@
 id: intro-events
 title: Hosting Events in Hubs
 sidebar_label: Hosting Events in Hubs
-description: Outlines the process of setting up Hubs for an event and inviting people
+description: This guide will talk you through the process of using Hubs for an event. This guide has different sections that can help you get started with creating and configuring a room, choosing a custom scene, inviting people, and moderating your event.
 ---
 
 <!-- This guide will talk you through the process of using Hubs for an event on [Mozilla Hubs](https://hubs.mozilla.com). We've broken this guide down into different sections that can help you get started with creating and configuring a room, choosing a custom scene, inviting people, and moderating your event.  -->

--- a/docs/intro-hubs.md
+++ b/docs/intro-hubs.md
@@ -2,7 +2,7 @@
 id: intro-hubs
 title: Getting Started with Hubs
 sidebar_label: Getting Started With Hubs
-description: How to enter a Hubs room, move around, basic interaction, add media, and invite friends.
+description: Once inside of Hubs, the user interface in the 3D viewport area contains options including muting/unmuting, sharing a screen, placing objects, reacting with emojis, opening a chat window, inviting other users into the space, and the exit (Leave) button.
 ---
 
 

--- a/docs/intro-spoke.md
+++ b/docs/intro-spoke.md
@@ -2,6 +2,7 @@
 id: intro-spoke
 title: Building Scenes with Spoke
 sidebar_label: Building Scenes with Spoke
+description: Spoke is an online 3D scene editor that allows users to create, discover, and share environments. Using a basic interface, users can upload, drag and drop, and edit assets like 3D models, sounds, lights, and links. Spoke is a good interface for beginners.
 ---
 
 Want to build custom VR worlds for Hubs? Meet [Spoke](https://github.com/Hubs-Foundation/Spoke)! 👋

--- a/docs/set-up-SMTP-email-service.md
+++ b/docs/set-up-SMTP-email-service.md
@@ -1,6 +1,7 @@
 ---
 id: set-up-SMTP-email-service
 title: Set up SMTP email service
+description: Instructions how to set up a simple mail transfer protocol (SMTP) email service to verify user accounts. Details include setting up an account at Scaleway, connecting it to Porkbun for domain verification and generating an API token. These items are needed for setting up your own Hubs instance.
 ---
 
 Hubs software needs to send out emails with magic links to verify that your visitors are real people and \*not\* sentient AI bots here to destroy humanity. 🤖

--- a/docs/setup-configuring-content.md
+++ b/docs/setup-configuring-content.md
@@ -1,6 +1,7 @@
 ---
 id: setup-configuring-content
 title: Managing Your Hub's Content
+description: A manual for managing Hubs content like scenes, avatars, accounts, projects, logos, branding, and settings.
 ---
 
 _This page serves as a manual for many of the features that are available to Hubs users to manage the content on their Hub._

--- a/docs/setup-contact.md
+++ b/docs/setup-contact.md
@@ -1,6 +1,7 @@
 ---
 id: setup-contact
 title: Contact Us
+description: Our contact information including email, our Discord server, and how to submit ideas for Hubs.
 ---
 
 _These are the best ways to get in touch with us and the community if you need help or are interested in learning more about Hubs._

--- a/docs/setup-faq.md
+++ b/docs/setup-faq.md
@@ -1,7 +1,7 @@
 ---
 id: setup-faq
 title: Frequently Asked Questions
-description: The terminology and limits of Hubs, and custom versions
+description: Frequently asked questions about Hubs basic use: accounts, exceeding Hubs limits, and the Hubs GitHub repository.
 ---
 
 ## Can I have more than one Hub with my account?

--- a/docs/sharing-avatar-links-privately.md
+++ b/docs/sharing-avatar-links-privately.md
@@ -2,6 +2,7 @@
 id: sharing-avatar-links-privately
 title: Sharing Avatar Links Privately
 sidebar_label: Sharing Avatar Links Privately
+description: Avatars can be shared via direct links. Hubs rooms can be created as dressing rooms so that users to a particular scene (instance?) are restricted to using only specific avatars.
 ---
 
 **Do you have a hubs room where you want specific avatars to be available for specific people but not others?

--- a/docs/spoke-adding-scene-content.md
+++ b/docs/spoke-adding-scene-content.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-adding-scene-content
 title: Adding Content
+description: Entire Hubs scenes should not be larger than 128MB in size. However, users can adding a wide variety of content including 3D models, images, videos, video, audio, particle emitters, links, and media frames. There are also 3D model spawners and audio zones.
 ---
 
 Once you have created your scene, you can start customizing it by adding content. Spoke and Hubs support a wide variety of media. Note that to publish to Hubs, Spoke projects have a size limit of 128MB.

--- a/docs/spoke-architecture-kit.md
+++ b/docs/spoke-architecture-kit.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-architecture-kit
 title: Architecture Kit
+description: The Spoke Architecture Kit includes over 400 building pieces so that users can easily create their own models and scenes.  Kit pieces are single-sided by default but can be made double-sided. Trim pieces help cover wall gaps.
 ---
 
 With the launch of the Architecture Kit, creators now have an additional way to build custom content for their 3D scenes without using an external tool. The Architecture Kit is designed to make it easier to take existing components that have already been optimized for VR and make it easy to configure those pieces to create original models and scenes. 

--- a/docs/spoke-controls.md
+++ b/docs/spoke-controls.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-controls
 title: Spoke Controls
+description: Spoke controls can be a little disorienting at first. Mouse and keyboard use is defined.
 ---
 
 We recommend using spoke on a desktop or laptop computer as some features are not accessible without a mouse and keyboard. 

--- a/docs/spoke-creating-projects.md
+++ b/docs/spoke-creating-projects.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-creating-projects
 title: Create Project
+description: New scenes or builds in Spoke are called projects.  Scenes can be newly created directly with Spoke or can be remixed from other Hubs rooms or imported from Spoke files.
 ---
 In Spoke, you can either create a new project from Scratch, remix an existing Hubs scene, or import a Spoke project someone sends you. 
 

--- a/docs/spoke-grid.md
+++ b/docs/spoke-grid.md
@@ -1,7 +1,7 @@
 ---
 id: spoke-grid
 title: Grid
-description: Grid and Snap Mode of Spoke
+description: Spoke contains a default one-half meter grid and snapping to that grid. Those settings can be changed.
 ---
 
 ![Screenshot of Spoke](img/spoke-grid.png)

--- a/docs/spoke-lighting-and-shadows.md
+++ b/docs/spoke-lighting-and-shadows.md
@@ -1,7 +1,7 @@
 ---
 id: lighting-and-shadows
 title: Lighting and Shadows
-description: Types of lights, shadow settings, and performance impacts in Spoke
+description: Lighting settings can be changed in Spoke, including types of light sources like ambient and spot lights. Shadows also can be changed. Lighting results can vary between desktop and mobile devices.
 ---
 
 ## Lights

--- a/docs/spoke-physics-and-navigation.md
+++ b/docs/spoke-physics-and-navigation.md
@@ -1,7 +1,7 @@
 ---
 id: physics-and-navigation
 title: Physics and Navigation
-description: Constraining where avatars can and can't go
+description: Spoke scenes require a floorplan to work (or Hubs does not know where to place, aka spawn, arriving avatars). Floorplans consist of navigation meshes (nav mesh) and collision meshes.
 ---
 
 # The Floorplan Element

--- a/docs/spoke-publish-scenes.md
+++ b/docs/spoke-publish-scenes.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-publish-scenes
 title: Publish Scenes
+description: Publishing a Spoke scene creates a unique URL that can optionally be shared or you can create a Hubs room immediately to go in to look around.  Spoke scenes can be exported as glb or spoke files.
 ---
 
 You can publish a scene either directly to Hubs, or you can export it as a .glb file or as a legacy Spoke scene. 

--- a/docs/spoke-skyboxes.md
+++ b/docs/spoke-skyboxes.md
@@ -1,6 +1,7 @@
 ---
 id: spoke-skyboxes
 title: Skyboxes
+description: Skyboxes simulate the sky or other backdrops around scenes.  Modifiable skybox properties include time of day, latitude, scattering, and horizon distances. A 360 image can also be a skybox.
 ---
 
 Skyboxes can significantly impact the ambience of your scene. Unless you have started from a template that removed the default elements, you should have a skybox in your scene when you begin. 

--- a/docs/spoke-user-interface.md
+++ b/docs/spoke-user-interface.md
@@ -1,7 +1,7 @@
 ---
 id: spoke-user-interface
 title: User Interface
-description: Menus, tools, mouse actions, info panels, assets and publishing in Spoke
+description: How to use the Spoke drop down menus, transformation and grid tools, and hierarchy, properties, and asset panels.
 ---
 
 ![Hubs Image](img/spoke-user-interface.jpeg)

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -2,7 +2,7 @@
 id: welcome
 title: Welcome to Hubs
 sidebar_label: Welcome
-description: Hubs is a virtual collaboration platform that runs in your browser. With Hubs you can create your own 3D spaces with a single click. Invite others to join using a URL. No installation or app store required.
+description: Hubs is an open-source virtual collaboration platform that runs in a browser, no special software needed. Hubs Docs is the documentation and instructions for how to set up and use Hubs. Hubs contains Spoke, a web-based scene editor so that users can create directly in the browser.
 ---
 
 **Important Notice:** A significant portion of this documentation contains outdated information.  There are ongoing efforts to update it. Chiefly, Hubs by Mozilla and Hubs Cloud are obsolete.  Hubs Community Edition has the same user experience.  Got questions?  Our community Discord is standing by.  https://discord.gg/hubs-498741086295031808

--- a/docs/whats-next.md
+++ b/docs/whats-next.md
@@ -1,6 +1,7 @@
 ---
 id: whats-next
 title: What’s next?
+description: Instructions for new Hubs instance actions including how to create a room, import a scene, update the Hubs code that runs an instance, and admin settings via the Admin Panel and for data backups.
 ---
 
 ### My Hubs is up and running, now what do I do?


### PR DESCRIPTION
## What?
Updates page descriptions from hubs-query-string-parameters to whats-next.


## Why?
These updates explicitly adds a page description field to prevent accidental changes to page descriptions later and provides better summaries for social media previews.

## Limitations
Only the bottom 35 files of the alphabetical listing of all 70 Hubs docs were changed.


## Alternatives considered
None


## Open questions
Open to suggested edits.


## Additional details or related context
These descriptions are more detailed than what was previously there. Further page descriptions are expected covering the remaining pages.

