### PR TITLE
Modifies How much will this cost section

### DIFF
--- a/docs/beginners-guide-to-CE.md
+++ b/docs/beginners-guide-to-CE.md
@@ -19,7 +19,7 @@ These instructions are written for users, newbies, or non-developers. This Hubs 
 
 This Hubs build at DO supports 30-60 maximum concurrent users. Of course, heavy concurrent use *can* lower that number. YMMV
 
-The cost is US$36 per month minimum, plus ~US$1 annual for the first year domain (August 2024 prices).
+The cost is $38 USD per month minimum, plus ~$1 USD annual for the first year domain (August 2025 prices).
 
 Scaleway provides you magic link log-in emails (SMTP), and Porkbun provides a web domain with DNS service.
 

--- a/docs/beginners-guide-to-CE.md
+++ b/docs/beginners-guide-to-CE.md
@@ -40,7 +40,7 @@ We estimate that proficient users might get this done in 45 minutes to 2 hours. 
 
 ### How much will this cost?
 
-We estimate US$1 per year for the first year of a domain and US$36 per month minimum. Your email SMTP service might be free or might cost a small amount of money (US$1-$5 per month). It might be safe to estimate US$40 per month.
+We estimate $1 USD per year for the first year of a domain and ~$5 USD for renewals each year.  ~$38 USD per month minimum for the services at DigitalOcean (this will include 1 node - $24 USD, 1 load balancer - $12 USD, and ~$2 USD for storage, one dollar for each 10 Gi volume). Your email SMTP service might be free or might cost a small amount of money ($1-$5 USD per month). It might be safe to estimate $40 USD per month.
 
 ### Got questions?
 


### PR DESCRIPTION
## What?
Modifies the How much will this cost section at the start of the Beginners Guide. Makes clear total estimate cost per normal user rises from $36US per month to $40US per month. Data backups are not mentioned in this section as those were add-on services at DO, addressed in the How to backup your Hubs instance doc.

## Why?
This section advises users of the costs upfront. The upcoming upgrade to Hubs CE changes the data storage at DigitalOcean. The cost per month for this storage is overall ~$2 less per month than the DO charge for their Backups. We feel that users should be informed of costs --even as estimates-- at the beginning of working on a Hubs Community Edition instance.

## Limitations
The section, What you will get, is not addressed currently in this PR. It might need to be also modified. [Update: Per discussion of 9/24/2025 - commit d5bc1c6f34ea1389a02780c7a7263a064ca1f798  DID address this.]

Note: this PR does not directly address that the Hubs CE upgrade of data storage will actually be, on the whole, **cheaper than comparatives** (and overall more stable) despite this change looking like the price estimate has increased $4US per month. The topic of benefits and overall lower costs is addressed in the planned upgrade notice and in the How to backup your Hubs instance doc.


## Alternatives considered
If we do not update this section of the Hubs documentation, new users might find their monthly DigitalOcean charges to be higher than they expected.


## Open questions
Should the What you will get section, this item be also changed?
The cost is US$36 per month minimum, plus ~US$1 annual for the first year domain (August 2024 prices).
[Update: Per discussion of 9/24/2025 - commit d5bc1c6f34ea1389a02780c7a7263a064ca1f798  DID address this.]


## Additional details or related context
If approved, should be merged with these: https://github.com/Hubs-Foundation/hubs-cloud/pull/387, #232  #230 

Comments welcome
